### PR TITLE
feat: implement Next.js frontend for blog application

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,34 @@
+# Dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# Testing
+/coverage
+
+# Next.js
+/.next/
+/out/
+
+# Production
+/build
+
+# Misc
+.DS_Store
+*.pem
+
+# Debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Local env files
+.env*.local
+
+# Vercel
+.vercel
+
+# TypeScript
+*.tsbuildinfo
+next-env.d.ts

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,45 @@
+# MyBlog Frontend
+
+Next.js で構築されたブログアプリケーションのフロントエンドです。
+
+## 機能
+
+- ブログ投稿の一覧表示
+- 投稿の詳細表示
+- 新規投稿作成
+- 投稿の編集・削除
+- 投稿の分析機能
+
+## 開発環境のセットアップ
+
+1. 依存関係のインストール:
+```bash
+npm install
+```
+
+2. 開発サーバーの起動:
+```bash
+npm run dev
+```
+
+3. ブラウザで http://localhost:3000 を開く
+
+## API連携
+
+このフロントエンドは、バックエンドAPI（デフォルト: http://localhost:8080）と連携します。
+バックエンドが起動していることを確認してください。
+
+## ビルド
+
+```bash
+npm run build
+npm start
+```
+
+## 技術スタック
+
+- Next.js 15
+- React 19
+- TypeScript
+- Tailwind CSS
+- ESLint

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+import './globals.css';
+import Link from 'next/link';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata: Metadata = {
+  title: 'MyBlog',
+  description: 'A simple blog application',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="ja">
+      <body className={inter.className}>
+        <div className="min-h-screen bg-gray-50">
+          <nav className="bg-white shadow-sm border-b">
+            <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+              <div className="flex justify-between h-16">
+                <div className="flex items-center">
+                  <Link href="/" className="text-xl font-bold text-gray-900">
+                    MyBlog
+                  </Link>
+                </div>
+                <div className="flex items-center space-x-4">
+                  <Link 
+                    href="/" 
+                    className="text-gray-700 hover:text-gray-900 px-3 py-2 rounded-md text-sm font-medium"
+                  >
+                    投稿一覧
+                  </Link>
+                  <Link 
+                    href="/posts/new" 
+                    className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md text-sm font-medium"
+                  >
+                    新規投稿
+                  </Link>
+                </div>
+              </div>
+            </div>
+          </nav>
+          <main className="max-w-4xl mx-auto py-6 sm:px-6 lg:px-8">
+            {children}
+          </main>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { api } from '@/lib/api';
+import { Post } from '@/types/api';
+
+export default function Home() {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      try {
+        const postList = await api.getPosts();
+        setPosts(postList.items);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch posts');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchPosts();
+  }, []);
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('この投稿を削除しますか？')) {
+      return;
+    }
+
+    try {
+      await api.deletePost(id);
+      setPosts(posts.filter(post => post.id !== id));
+    } catch (err) {
+      alert('削除に失敗しました');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <div className="text-gray-600">読み込み中...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-md p-4">
+        <div className="text-red-700">エラー: {error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 sm:px-0">
+      <div className="sm:flex sm:items-center">
+        <div className="sm:flex-auto">
+          <h1 className="text-2xl font-semibold text-gray-900">ブログ投稿一覧</h1>
+          <p className="mt-2 text-sm text-gray-700">
+            すべての投稿を表示しています
+          </p>
+        </div>
+      </div>
+
+      {posts.length === 0 ? (
+        <div className="text-center py-8">
+          <div className="text-gray-500">投稿がありません</div>
+          <Link 
+            href="/posts/new"
+            className="mt-2 inline-block text-blue-600 hover:text-blue-500"
+          >
+            最初の投稿を作成する
+          </Link>
+        </div>
+      ) : (
+        <div className="mt-8 flow-root">
+          <div className="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+            <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+              <div className="space-y-4">
+                {posts.map((post) => (
+                  <div key={post.id} className="bg-white rounded-lg shadow-sm border p-6">
+                    <div className="flex justify-between items-start">
+                      <div className="flex-1">
+                        <h3 className="text-lg font-medium text-gray-900">
+                          <Link 
+                            href={`/posts/${post.id}`}
+                            className="hover:text-blue-600"
+                          >
+                            {post.title}
+                          </Link>
+                        </h3>
+                        <p className="mt-2 text-gray-600 line-clamp-3">
+                          {post.body.length > 150 
+                            ? `${post.body.substring(0, 150)}...` 
+                            : post.body
+                          }
+                        </p>
+                        <div className="mt-4 text-sm text-gray-500">
+                          {post.publishdAt 
+                            ? `公開日: ${new Date(post.publishdAt).toLocaleDateString('ja-JP')}`
+                            : '下書き'
+                          }
+                        </div>
+                      </div>
+                      <div className="ml-4 flex space-x-2">
+                        <Link
+                          href={`/posts/${post.id}/edit`}
+                          className="text-blue-600 hover:text-blue-900 text-sm font-medium"
+                        >
+                          編集
+                        </Link>
+                        <button
+                          onClick={() => handleDelete(post.id)}
+                          className="text-red-600 hover:text-red-900 text-sm font-medium"
+                        >
+                          削除
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/posts/[id]/edit/page.tsx
+++ b/frontend/app/posts/[id]/edit/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { api } from '@/lib/api';
+import { Post } from '@/types/api';
+import PostForm from '@/components/PostForm';
+
+export default function EditPost() {
+  const params = useParams();
+  const router = useRouter();
+  const id = params.id as string;
+  
+  const [post, setPost] = useState<Post | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchPost = async () => {
+      try {
+        const postData = await api.getPost(id);
+        setPost(postData);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch post');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (id) {
+      fetchPost();
+    }
+  }, [id]);
+
+  const handleSubmit = async (data: { title: string; body: string; publishdAt: string | null }) => {
+    if (!post) return;
+    
+    await api.updatePost(post.id, data);
+    router.push(`/posts/${post.id}`);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <div className="text-gray-600">読み込み中...</div>
+      </div>
+    );
+  }
+
+  if (error || !post) {
+    return (
+      <div className="px-4 sm:px-0">
+        <div className="bg-red-50 border border-red-200 rounded-md p-4">
+          <div className="text-red-700">エラー: {error || '投稿が見つかりません'}</div>
+        </div>
+        <div className="mt-4">
+          <Link 
+            href="/"
+            className="text-blue-600 hover:text-blue-500"
+          >
+            ← 投稿一覧に戻る
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-6 px-4 sm:px-0">
+        <Link 
+          href={`/posts/${post.id}`}
+          className="text-blue-600 hover:text-blue-500 text-sm font-medium"
+        >
+          ← 投稿詳細に戻る
+        </Link>
+      </div>
+
+      <div className="mb-8 px-4 sm:px-0">
+        <h1 className="text-2xl font-semibold text-gray-900">投稿を編集</h1>
+        <p className="mt-2 text-sm text-gray-700">
+          「{post.title}」を編集しています
+        </p>
+      </div>
+
+      <PostForm 
+        post={post}
+        onSubmit={handleSubmit}
+        submitLabel="変更を保存"
+      />
+    </div>
+  );
+}

--- a/frontend/app/posts/[id]/page.tsx
+++ b/frontend/app/posts/[id]/page.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { api } from '@/lib/api';
+import { Post, AnalyzeResult } from '@/types/api';
+
+export default function PostDetail() {
+  const params = useParams();
+  const id = params.id as string;
+  
+  const [post, setPost] = useState<Post | null>(null);
+  const [analysis, setAnalysis] = useState<AnalyzeResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [analyzing, setAnalyzing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchPost = async () => {
+      try {
+        const postData = await api.getPost(id);
+        setPost(postData);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch post');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (id) {
+      fetchPost();
+    }
+  }, [id]);
+
+  const handleAnalyze = async () => {
+    if (!post) return;
+    
+    setAnalyzing(true);
+    try {
+      const result = await api.analyzePost(post.id);
+      setAnalysis(result);
+    } catch (err) {
+      alert('分析に失敗しました');
+    } finally {
+      setAnalyzing(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <div className="text-gray-600">読み込み中...</div>
+      </div>
+    );
+  }
+
+  if (error || !post) {
+    return (
+      <div className="px-4 sm:px-0">
+        <div className="bg-red-50 border border-red-200 rounded-md p-4">
+          <div className="text-red-700">エラー: {error || '投稿が見つかりません'}</div>
+        </div>
+        <div className="mt-4">
+          <Link 
+            href="/"
+            className="text-blue-600 hover:text-blue-500"
+          >
+            ← 投稿一覧に戻る
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 sm:px-0">
+      <div className="mb-6">
+        <Link 
+          href="/"
+          className="text-blue-600 hover:text-blue-500 text-sm font-medium"
+        >
+          ← 投稿一覧に戻る
+        </Link>
+      </div>
+
+      <article className="bg-white rounded-lg shadow-sm border p-8">
+        <header className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-4">
+            {post.title}
+          </h1>
+          <div className="flex justify-between items-center text-sm text-gray-500">
+            <div>
+              {post.publishdAt 
+                ? `公開日: ${new Date(post.publishdAt).toLocaleDateString('ja-JP')}`
+                : '下書き'
+              }
+            </div>
+            <div className="space-x-4">
+              <Link
+                href={`/posts/${post.id}/edit`}
+                className="text-blue-600 hover:text-blue-900 font-medium"
+              >
+                編集
+              </Link>
+              <button
+                onClick={handleAnalyze}
+                disabled={analyzing}
+                className="text-green-600 hover:text-green-900 font-medium disabled:opacity-50"
+              >
+                {analyzing ? '分析中...' : '投稿を分析'}
+              </button>
+            </div>
+          </div>
+        </header>
+
+        <div className="prose max-w-none">
+          <div className="whitespace-pre-wrap text-gray-800 leading-relaxed">
+            {post.body}
+          </div>
+        </div>
+      </article>
+
+      {analysis && (
+        <div className="mt-8 bg-green-50 border border-green-200 rounded-lg p-6">
+          <h3 className="text-lg font-medium text-green-900 mb-4">分析結果</h3>
+          <div className="text-green-800 whitespace-pre-wrap">
+            {analysis.analysis}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/posts/new/page.tsx
+++ b/frontend/app/posts/new/page.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { api } from '@/lib/api';
+import PostForm from '@/components/PostForm';
+
+export default function NewPost() {
+  const router = useRouter();
+
+  const handleSubmit = async (data: { title: string; body: string; publishdAt: string | null }) => {
+    await api.createPost(data);
+    router.push('/');
+  };
+
+  return (
+    <div>
+      <div className="mb-6 px-4 sm:px-0">
+        <Link 
+          href="/"
+          className="text-blue-600 hover:text-blue-500 text-sm font-medium"
+        >
+          ← 投稿一覧に戻る
+        </Link>
+      </div>
+
+      <div className="mb-8 px-4 sm:px-0">
+        <h1 className="text-2xl font-semibold text-gray-900">新規投稿</h1>
+        <p className="mt-2 text-sm text-gray-700">
+          新しいブログ投稿を作成します
+        </p>
+      </div>
+
+      <PostForm 
+        onSubmit={handleSubmit}
+        submitLabel="投稿を作成"
+      />
+    </div>
+  );
+}

--- a/frontend/components/PostForm.tsx
+++ b/frontend/components/PostForm.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Post } from '@/types/api';
+
+interface PostFormProps {
+  post?: Post;
+  onSubmit: (data: { title: string; body: string; publishdAt: string | null }) => Promise<void>;
+  submitLabel: string;
+}
+
+export default function PostForm({ post, onSubmit, submitLabel }: PostFormProps) {
+  const router = useRouter();
+  const [title, setTitle] = useState(post?.title || '');
+  const [body, setBody] = useState(post?.body || '');
+  const [isPublished, setIsPublished] = useState(!!post?.publishdAt);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!title.trim() || !body.trim()) {
+      alert('タイトルと本文を入力してください');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await onSubmit({
+        title: title.trim(),
+        body: body.trim(),
+        publishdAt: isPublished ? new Date().toISOString() : null,
+      });
+    } catch (err) {
+      alert('保存に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="px-4 sm:px-0">
+      <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-sm border p-8">
+        <div className="space-y-6">
+          <div>
+            <label htmlFor="title" className="block text-sm font-medium text-gray-700">
+              タイトル
+            </label>
+            <input
+              type="text"
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+              placeholder="投稿のタイトルを入力"
+              required
+            />
+          </div>
+
+          <div>
+            <label htmlFor="body" className="block text-sm font-medium text-gray-700">
+              本文
+            </label>
+            <textarea
+              id="body"
+              rows={12}
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+              placeholder="投稿の内容を入力"
+              required
+            />
+          </div>
+
+          <div className="flex items-center">
+            <input
+              id="published"
+              type="checkbox"
+              checked={isPublished}
+              onChange={(e) => setIsPublished(e.target.checked)}
+              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+            />
+            <label htmlFor="published" className="ml-2 block text-sm text-gray-700">
+              すぐに公開する
+            </label>
+          </div>
+
+          <div className="flex justify-between">
+            <button
+              type="button"
+              onClick={() => router.back()}
+              className="px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+            >
+              {submitting ? '保存中...' : submitLabel}
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,67 @@
+import { Post, PostList, PostMergePatchUpdate, AnalyzeResult, ApiError } from '@/types/api';
+
+const API_BASE_URL = process.env.NODE_ENV === 'production' ? '/api' : '/api';
+
+async function apiRequest<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+  const url = `${API_BASE_URL}${endpoint}`;
+  
+  const response = await fetch(url, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+    ...options,
+  });
+
+  if (!response.ok) {
+    const error: ApiError = await response.json();
+    throw new Error(`API Error: ${error.message}`);
+  }
+
+  return response.json();
+}
+
+export const api = {
+  // Get all posts
+  getPosts: (): Promise<PostList> => {
+    return apiRequest<PostList>('/posts');
+  },
+
+  // Get a single post by ID
+  getPost: (id: string): Promise<Post> => {
+    return apiRequest<Post>(`/posts/${id}`);
+  },
+
+  // Create a new post
+  createPost: (post: Omit<Post, 'id'>): Promise<Post> => {
+    return apiRequest<Post>('/posts', {
+      method: 'POST',
+      body: JSON.stringify(post),
+    });
+  },
+
+  // Update a post
+  updatePost: (id: string, updates: PostMergePatchUpdate): Promise<Post> => {
+    return apiRequest<Post>(`/posts/${id}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/merge-patch+json',
+      },
+      body: JSON.stringify(updates),
+    });
+  },
+
+  // Delete a post
+  deletePost: (id: string): Promise<void> => {
+    return apiRequest<void>(`/posts/${id}`, {
+      method: 'DELETE',
+    });
+  },
+
+  // Analyze a post
+  analyzePost: (id: string): Promise<AnalyzeResult> => {
+    return apiRequest<AnalyzeResult>(`/posts/${id}/analyze`, {
+      method: 'POST',
+    });
+  },
+};

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://localhost:8080/api/:path*',
+      },
+    ];
+  },
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "myblog-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^15.1.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "typescript": "^5",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
+  },
+  "devDependencies": {
+    "eslint": "^8",
+    "eslint-config-next": "^15.1.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "es6"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -1,0 +1,27 @@
+export interface Post {
+  id: string;
+  title: string;
+  body: string;
+  publishdAt: string | null;
+}
+
+export interface PostList {
+  items: Post[];
+}
+
+export interface PostMergePatchUpdate {
+  id?: string;
+  title?: string;
+  body?: string;
+  publishdAt?: string | null;
+}
+
+export interface AnalyzeResult {
+  id: string;
+  analysis: string;
+}
+
+export interface ApiError {
+  code: number;
+  message: string;
+}


### PR DESCRIPTION
OpenAPI スキーマをベースにNext.jsを使用してブログのフロントエンドを実装しました。

## 実装内容
- Next.js 15 + TypeScript + Tailwind CSS
- タイプセーフなAPIクライアント
- 投稿のCRUD操作
- 投稿分析機能
- レスポンシブデザイン

Fixes #6

Generated with [Claude Code](https://claude.ai/code)